### PR TITLE
Memory improvements

### DIFF
--- a/src/Object/Object.cpp
+++ b/src/Object/Object.cpp
@@ -6,7 +6,7 @@ pos(p){
 }
 
 Object::~Object(){
-	SDL_DestroyTexture(this->txt);
+	/* SDL_DestroyTexture(this->txt); */
 }
 
 void Object::Move(glm::vec2 && v){

--- a/src/Object/Object.cpp
+++ b/src/Object/Object.cpp
@@ -6,7 +6,7 @@ pos(p){
 }
 
 Object::~Object(){
-	/* SDL_DestroyTexture(this->txt); */
+    if(txt) SDL_DestroyTexture(txt);
 }
 
 void Object::Move(glm::vec2 && v){

--- a/src/Window/Window.cpp
+++ b/src/Window/Window.cpp
@@ -11,7 +11,6 @@ renderer( SDL_CreateRenderer(this->window,
 			-1,
 			SDL_RENDERER_ACCELERATED))
 {
-	SDL_Init(SDL_INIT_VIDEO);
 }
 
 Window::~Window(){

--- a/src/Window/Window.cpp
+++ b/src/Window/Window.cpp
@@ -15,8 +15,8 @@ renderer( SDL_CreateRenderer(this->window,
 }
 
 Window::~Window(){
-	SDL_DestroyWindow(window);
 	SDL_DestroyRenderer(renderer);
+	SDL_DestroyWindow(window);
 }
 
 void Window::Draw() const{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,11 @@
 #include <SDL2/SDL_events.h>
 
 int main(){
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        SDL_Log("Unable to initialize SDL: %s", SDL_GetError());
+        return 1;
+    }
+
 	auto e = std::make_unique<Engine>(800, 600);
 	auto c = std::make_shared<Ball>(glm::vec2(400, 300), 10);
 	e->PushObject(c);
@@ -11,5 +16,4 @@ int main(){
 		c->Move(glm::vec2(10,-20));
 		SDL_Delay(100);
 	}
-
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@ int main(){
         SDL_Log("Unable to initialize SDL: %s", SDL_GetError());
         return 1;
     }
+    atexit(SDL_Quit);
 
 	auto e = std::make_unique<Engine>(800, 600);
 	auto c = std::make_shared<Ball>(glm::vec2(400, 300), 10);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,11 +9,11 @@ int main(){
     }
     atexit(SDL_Quit);
 
-	auto e = std::make_unique<Engine>(800, 600);
+	auto e = Engine(800, 600);
 	auto c = std::make_shared<Ball>(glm::vec2(400, 300), 10);
-	e->PushObject(c);
+	e.PushObject(c);
 	for(int i=0; i<10; i++){
-		e->Draw();
+		e.Draw();
 		c->Move(glm::vec2(10,-20));
 		SDL_Delay(100);
 	}


### PR DESCRIPTION
Bunch of improvements related with memory (de)allocation

NOTE: even after this changes, valgrind keeps bugging me about that not all memory allocated by SDL_Init is freed. [Looks like this is normal](https://stackoverflow.com/questions/1997171/why-does-valgrind-say-basic-sdl-program-is-leaking-memory), and we should not be bothered by that. After all, not freeing resource used through whole program lifetime is not real issue